### PR TITLE
Create the stack base directory when importing a stack if it does not…

### DIFF
--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -241,7 +241,10 @@ func (c *Config) Import(filePath string) error {
 
 	stackBasedir := filepath.Join(c.StackConfig.InstallDir, c.StackDefinition.Name)
 	if !util.PathExists(stackBasedir) {
-		return fmt.Errorf("%s does not exist", stackBasedir)
+		err := os.MkdirAll(stackBasedir, defaultPermission)
+		if err != nil {
+			return fmt.Errorf("unable to create %s: %w", stackBasedir, err)
+		}
 	}
 
 	tarBin, err := exec.LookPath("tar")


### PR DESCRIPTION
… already exist