### PR TITLE
Release v1.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/gvallee/go_software_build
 
-go 1.20
+go 1.22.1
 
 require (
-	github.com/gvallee/go_exec v1.2.2
+	github.com/gvallee/go_exec/v2 v2.0.2
 	github.com/gvallee/go_util v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
-github.com/gvallee/go_exec v1.2.2 h1:0gWUN/zHAl6bZiLBSNAtBtwD1GvUBOavpM9Lnp7ke+A=
-github.com/gvallee/go_exec v1.2.2/go.mod h1:lmOyPu3oseS+RDHpd/AEJD4x/XWEPVYsQ+A++uoeLdM=
-github.com/gvallee/go_util v1.6.0/go.mod h1:fTexpwdH/n05Ziu0TXJIQsr7E+46QpBxNdeOOsyC0/s=
+github.com/gvallee/go_exec/v2 v2.0.2 h1:2S4JWmC7ZZTTJuUSFe8rClMaX7b+3RqWJe+GoTczXA0=
+github.com/gvallee/go_exec/v2 v2.0.2/go.mod h1:oqQQK0MyyRdbDj44/BGuCJhfBrGtyuMWHDH8ozy0WOI=
 github.com/gvallee/go_util v1.7.0 h1:jrJ7EfmgUm/O4Zk83qy2anrfa24gfEx0z5wqEK+wDOY=
 github.com/gvallee/go_util v1.7.0/go.mod h1:bl3o2Gt/t3yIkck2Q/ubGqZoiBXI/PD05VvypI170D0=

--- a/internal/pkg/autotools/autotools.go
+++ b/internal/pkg/autotools/autotools.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gvallee/go_exec/pkg/advexec"
+	"github.com/gvallee/go_exec/v2/pkg/advexec"
 	"github.com/gvallee/go_util/pkg/util"
 )
 

--- a/pkg/buildenv/buildenv.go
+++ b/pkg/buildenv/buildenv.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gvallee/go_exec/pkg/advexec"
+	"github.com/gvallee/go_exec/v2/pkg/advexec"
 	"github.com/gvallee/go_software_build/pkg/app"
 	"github.com/gvallee/go_util/pkg/util"
 )

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -15,7 +15,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/gvallee/go_exec/pkg/advexec"
+	"github.com/gvallee/go_exec/v2/pkg/advexec"
 	"github.com/gvallee/go_software_build/internal/pkg/autotools"
 	"github.com/gvallee/go_software_build/pkg/app"
 	"github.com/gvallee/go_software_build/pkg/buildenv"

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gvallee/go_exec/pkg/advexec"
+	"github.com/gvallee/go_exec/v2/pkg/advexec"
 	"github.com/gvallee/go_util/pkg/util"
 )
 


### PR DESCRIPTION
Update go_exec to v2.0.2, validate compatibility and tests. All tests pass, no breaking changes detected, dependencies cleaned.